### PR TITLE
Normalize guide emotion/character inference

### DIFF
--- a/src/lib/guideInference.ts
+++ b/src/lib/guideInference.ts
@@ -1,0 +1,113 @@
+import type { CharacterId, EmotionId, GuideWithCharacter } from "@/types/ai";
+
+export type EmotionSource =
+  | "emotionId"
+  | "emotion"
+  | "id"
+  | "tags"
+  | "fallback";
+
+export type CharacterSource =
+  | "characterId"
+  | "character"
+  | "id"
+  | "fallback";
+
+export type GuideInference = {
+  emotionId: EmotionId;
+  characterId: CharacterId;
+  emotionSource: EmotionSource;
+  characterSource: CharacterSource;
+};
+
+export function normalizeEmotionInput(
+  value?: string
+): EmotionId | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "miedo") return "miedo";
+  if (normalized === "ira") return "ira";
+  if (normalized === "tristeza") return "tristeza";
+  if (normalized === "verguenza" || normalized === "vergüenza")
+    return "verguenza";
+  if (normalized === "celos") return "celos";
+  if (normalized === "alegria" || normalized === "alegría")
+    return "alegria";
+  return undefined;
+}
+
+export function parseGuideId(
+  value?: string
+): { emotion?: EmotionId; character?: CharacterId } {
+  if (!value) return {};
+  const match = value.trim().toLowerCase().match(/^story_([^_]+)_([^_]+)$/);
+  if (!match) return {};
+  const emotion = normalizeEmotionInput(match[1]);
+  const character =
+    match[2] === "yachay" || match[2] === "amaru" ? match[2] : undefined;
+  return { emotion, character };
+}
+
+export function resolveEmotionId(
+  guide: Partial<GuideWithCharacter>
+): { emotionId: EmotionId; source: EmotionSource } {
+  if (guide.emotionId) {
+    return { emotionId: guide.emotionId, source: "emotionId" };
+  }
+
+  const directEmotion =
+    normalizeEmotionInput((guide as { emotion?: string }).emotion) ?? undefined;
+  if (directEmotion) {
+    return { emotionId: directEmotion, source: "emotion" };
+  }
+
+  const parsed = parseGuideId(guide.id);
+  if (parsed.emotion) {
+    return { emotionId: parsed.emotion, source: "id" };
+  }
+
+  if (Array.isArray(guide.tags)) {
+    for (const tag of guide.tags) {
+      const normalized = normalizeEmotionInput(tag);
+      if (normalized) {
+        return { emotionId: normalized, source: "tags" };
+      }
+    }
+  }
+
+  return { emotionId: "miedo", source: "fallback" };
+}
+
+export function resolveCharacterId(
+  guide: Partial<GuideWithCharacter>,
+  emotionId: EmotionId
+): { characterId: CharacterId; source: CharacterSource } {
+  if (guide.characterId === "yachay" || guide.characterId === "amaru") {
+    return { characterId: guide.characterId, source: "characterId" };
+  }
+
+  if (guide.character === "yachay" || guide.character === "amaru") {
+    return { characterId: guide.character, source: "character" };
+  }
+
+  const parsed = parseGuideId(guide.id);
+  if (parsed.character) {
+    return { characterId: parsed.character, source: "id" };
+  }
+
+  const fallback = emotionId === "ira" ? "amaru" : "yachay";
+  return { characterId: fallback, source: "fallback" };
+}
+
+export function inferGuideContext(
+  guide: Partial<GuideWithCharacter>
+): GuideInference {
+  const emotion = resolveEmotionId(guide);
+  const character = resolveCharacterId(guide, emotion.emotionId);
+  return {
+    emotionId: emotion.emotionId,
+    characterId: character.characterId,
+    emotionSource: emotion.source,
+    characterSource: character.source,
+  };
+}


### PR DESCRIPTION
## Summary
- centralize emotion/character inference in guideInference
- reuse inference in assistant guide generation and story export trigger
- log resolved sources for traceability

## Testing
- not run (not requested)

Closes #10
