### PR TITLE
Log story cache hits and misses

### DIFF
--- a/src/lib/storyExport.ts
+++ b/src/lib/storyExport.ts
@@ -101,6 +101,10 @@ export async function generateStoryExport(
     const cachedRes = await fetch(cachedUrl.publicUrl);
     if (cachedRes.ok) {
       const cachedStory = (await cachedRes.json()) as Story;
+      console.info("[story/export] Cache hit", {
+        cacheKey,
+        url: cachedUrl.publicUrl,
+      });
       timings.push({ label: "TOTAL", ms: performance.now() - totalStart });
       return {
         story: cachedStory,
@@ -111,6 +115,7 @@ export async function generateStoryExport(
     }
   } catch (err) {
     // Cache miss or invalid cached data; continue to regenerate.
+    console.info("[story/export] Cache miss", { cacheKey });
   }
 
   const story = await timeAsync(timings, "generateStory", () =>


### PR DESCRIPTION
## Summary
- log cache hit/miss for generated story JSON
- include cache key and URL in logs

## Testing
- not run (not requested)
