### PR TITLE
Spec 001: PostHog product funnel instrumentation

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,6 +22,10 @@ NEXT_PUBLIC_STORY_ESTIMATE_MS=120000
 EVAL_TIMEOUT_MS=15000
 EVAL_MAX_CASES=40
 
+# PostHog (analytics de producto; opcional, no-op si falta la key)
+NEXT_PUBLIC_POSTHOG_KEY=phc_your_project_api_key
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # Sentry
 NEXT_PUBLIC_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.11.0",
+    "@mundo/core": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@sentry/nextjs": "^10.35.0",
@@ -24,6 +25,8 @@
     "lucide-react": "^0.487.0",
     "next": "^16.1.0",
     "openai": "^5.10.2",
+    "p-limit": "^4.0.0",
+    "posthog-js": "^1.386.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-icons": "^5.5.0",
@@ -32,9 +35,7 @@
     "sonner": "^2.0.7",
     "tone": "^15.0.4",
     "zod": "^3.25.76",
-    "zustand": "^5.0.3",
-    "@mundo/core": "workspace:*",
-    "p-limit": "^4.0.0"
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/web/src/hooks/useAssistant.ts
+++ b/apps/web/src/hooks/useAssistant.ts
@@ -1,8 +1,11 @@
 import type { GuideWithCharacter } from "@/types/ai";
 import { useState, useEffect } from "react";
-import { useAuthStore } from "@/store/useAuthStore";
 import { authFetch } from "@/lib/authFetch";
 import { inferGuideContext } from "@/lib/guideInference";
+import {
+  trackGuiaGenerada,
+  trackGuiaGeneracionFallida,
+} from "@/lib/analytics";
 
 const loadingMessages = [
   "Contactando a Aynia...",
@@ -87,8 +90,29 @@ export function useMundoAssistant() {
       );
       console.log("[useAssistant] finalGuide:", finalGuide);
 
+      const metadata = rawData?._metadata as
+        | {
+            aiProvider?: string;
+            fallback?: string;
+            emotionSource?: string;
+          }
+        | undefined;
+      trackGuiaGenerada({
+        emotion,
+        provider: metadata?.aiProvider,
+        fallback: Boolean(metadata?.fallback),
+        emotionSource: metadata?.emotionSource,
+        queryLength: query.length,
+      });
+
       setGuide(finalGuide);
     } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "An unexpected error occurred.";
+      trackGuiaGeneracionFallida({
+        errorMessage: message,
+        queryLength: query.length,
+      });
       if (err instanceof Error) {
         setError(err.message);
       } else {

--- a/apps/web/src/hooks/useJourneyAudio.tsx
+++ b/apps/web/src/hooks/useJourneyAudio.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Howl } from "howler";
+import { trackCuentoAudioReproducido } from "@/lib/analytics";
 
 interface UseJourneyAudioProps {
   onStepComplete: () => void;
@@ -35,7 +36,7 @@ export function useJourneyAudio({
         html5: true, // Usar audio HTML5 (importante para PWA/Service Workers/Caching)
         onplay: () => {
           setIsPlaying(true);
-          // console.log(`Audio playing: ${src}`);
+          trackCuentoAudioReproducido();
         },
         onend: () => {
           // Asegurarse de que onStepComplete se llame solo una vez por reproducción

--- a/apps/web/src/hooks/useSavedGuides.ts
+++ b/apps/web/src/hooks/useSavedGuides.ts
@@ -2,6 +2,7 @@ import { GuideWithCharacter } from "@/types/ai";
 import { useEffect, useState } from "react";
 import { useAuthStore } from "@/store/useAuthStore";
 import { authFetch } from "@/lib/authFetch";
+import { trackGuiaGuardada } from "@/lib/analytics";
 
 export function useSavedGuides() {
   const [savedGuides, setSavedGuides] = useState<GuideWithCharacter[]>([]);
@@ -97,6 +98,10 @@ export function useSavedGuides() {
     }
 
     const data = await res.json();
+    trackGuiaGuardada({
+      emotion: normalizedGuide.emotionId,
+      character: normalizedGuide.characterId,
+    });
     setSavedGuides((prev) => {
       const next = prev.filter((g) => g.id !== normalizedGuide.id);
       return [normalizeGuide(data.guide as GuideWithCharacter), ...next];

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -3,6 +3,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { initAnalytics } from "@/lib/analytics";
+
+initAnalytics();
 
 const tracesSampleRate = Number(
   process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? 0.1

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,71 @@
+import posthog from "posthog-js";
+
+// Privacidad: nunca enviar texto libre del usuario (consultas, contenido
+// de guías). Solo metadatos de comportamiento. Ver docs/specs/001.
+
+const isEnabled = () =>
+  typeof window !== "undefined" &&
+  Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY);
+
+export function initAnalytics() {
+  if (!isEnabled()) return;
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
+    api_host:
+      process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+    defaults: "2025-05-24",
+  });
+}
+
+export function identifyUser(userId: string, props?: { role?: string }) {
+  if (!isEnabled()) return;
+  posthog.identify(userId, props);
+}
+
+export function resetAnalytics() {
+  if (!isEnabled()) return;
+  posthog.reset();
+}
+
+type GuiaGeneradaProps = {
+  emotion?: string;
+  provider?: string;
+  fallback?: boolean;
+  emotionSource?: string;
+  queryLength: number;
+};
+
+export function trackRegistroCompletado(props?: { role?: string }) {
+  if (!isEnabled()) return;
+  posthog.capture("registro_completado", props);
+}
+
+export function trackLogin() {
+  if (!isEnabled()) return;
+  posthog.capture("login");
+}
+
+export function trackGuiaGenerada(props: GuiaGeneradaProps) {
+  if (!isEnabled()) return;
+  posthog.capture("guia_generada", props);
+}
+
+export function trackGuiaGeneracionFallida(props: {
+  errorMessage: string;
+  queryLength: number;
+}) {
+  if (!isEnabled()) return;
+  posthog.capture("guia_generacion_fallida", props);
+}
+
+export function trackGuiaGuardada(props: {
+  emotion?: string;
+  character?: string;
+}) {
+  if (!isEnabled()) return;
+  posthog.capture("guia_guardada", props);
+}
+
+export function trackCuentoAudioReproducido() {
+  if (!isEnabled()) return;
+  posthog.capture("cuento_audio_reproducido");
+}

--- a/apps/web/src/services/authService.tsx
+++ b/apps/web/src/services/authService.tsx
@@ -1,3 +1,10 @@
+import {
+  identifyUser,
+  resetAnalytics,
+  trackLogin,
+  trackRegistroCompletado,
+} from "@/lib/analytics";
+
 interface RegistrationPayload {
   email: string;
   password: string;
@@ -47,7 +54,10 @@ export async function registerUser(
     throw new Error(errorMessage);
   }
 
-  return result as RegistrationSuccessResponse;
+  const registration = result as RegistrationSuccessResponse;
+  identifyUser(registration.userId, { role: payload.role });
+  trackRegistroCompletado({ role: payload.role });
+  return registration;
 }
 
 export async function loginUser(
@@ -71,7 +81,10 @@ export async function loginUser(
     throw new Error(errorMessage);
   }
 
-  return result as LoginSuccessResponse;
+  const login = result as LoginSuccessResponse;
+  identifyUser(login.userId, { role: login.role });
+  trackLogin();
+  return login;
 }
 
 interface LogoutResponse {
@@ -96,5 +109,6 @@ export async function logoutUser(): Promise<LogoutResponse> {
     throw new Error(errorMessage);
   }
 
+  resetAnalytics();
   return result as LogoutResponse;
 }

--- a/docs/specs/001-analytics-funnel.md
+++ b/docs/specs/001-analytics-funnel.md
@@ -1,0 +1,57 @@
+# 001 — Funnel de producto con PostHog
+
+## Problema
+
+No tenemos visibilidad de cómo se usa mundo. Sentry reporta errores y
+`openaiMetrics` cuenta llamadas, pero no podemos responder: ¿cuántos
+usuarios generan una guía? ¿cuántos la guardan? ¿cuántos vuelven?
+Sin esto, ningún experimento de adquisición (SEO, campañas, landing)
+es interpretable.
+
+## Solución
+
+Instrumentar el funnel core con PostHog (posthog-js, ya instalado):
+
+```
+registro → guía generada → guía guardada → cuento escuchado → retorno
+```
+
+- Inicialización en `instrumentation-client.ts` (junto a Sentry),
+  solo si `NEXT_PUBLIC_POSTHOG_KEY` está definida.
+- Wrapper tipado en `src/lib/analytics.ts` — los componentes nunca
+  importan posthog directamente.
+- `identify(userId)` en login/registro, `reset()` en logout.
+- Pageviews automáticos (incluye navegación SPA).
+
+## Eventos
+
+| Evento | Dónde | Propiedades |
+|--------|-------|-------------|
+| `registro_completado` | `authService.registerUser` | role |
+| `login` | `authService.loginUser` | — |
+| `guia_generada` | `useAssistant.generateGuide` | emotion, provider, fallback, emotionSource, queryLength |
+| `guia_generacion_fallida` | `useAssistant.generateGuide` | errorMessage |
+| `guia_guardada` | `useSavedGuides.saveGuide` | emotion, character |
+| `cuento_audio_reproducido` | `useJourneyAudio.playAudio` | — |
+
+La retención (retorno a 7 días) la calcula PostHog con identify + pageviews.
+
+## Privacidad (no negociable)
+
+**Nunca enviar el texto de la consulta del padre ni contenido de la guía.**
+Solo metadatos (emoción, proveedor, flags, longitud). El producto maneja
+datos emocionales de niños; PostHog solo recibe comportamiento.
+
+## Criterios de aceptación
+
+- [ ] Con `NEXT_PUBLIC_POSTHOG_KEY` ausente, la app funciona igual (no-op).
+- [ ] Los 6 eventos aparecen en PostHog al ejercitar el flujo.
+- [ ] `identify` vincula eventos al userId; logout hace `reset`.
+- [ ] Ninguna propiedad contiene texto libre del usuario.
+- [ ] Variables documentadas en `.env.example`.
+
+## Fuera de alcance (futuros issues)
+
+- `guia_leida_completa` (scroll/tiempo de lectura) — v1.1.
+- Eventos server-side (fallback rate exacto desde la API).
+- Dashboards/insights en PostHog (se configuran en la UI, no en código).

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,26 @@
+# Specs — flujo de trabajo
+
+Spec-driven development para un equipo de 1 persona. Regla central:
+**si no está en el spec, es otro issue.** Así evitamos PRs monstruo.
+
+## Ciclo
+
+1. **Spec** — archivo `NNN-nombre.md` en esta carpeta. Corto: problema,
+   solución propuesta, criterios de aceptación, fuera de alcance.
+2. **Issue** — se crea en GitHub referenciando el spec. Es el backlog visible.
+3. **Rama** — `feat/...` o `fix/...` desde `main`, vive 1-3 días máximo.
+4. **Commits** — pequeños y temáticos (docs / feature / wiring por separado).
+5. **PR** — cierra el issue con `Closes #N`. Merge a `main`, la rama muere.
+
+No usamos rama `develop`: `main` siempre es deployable (trunk-based).
+Vercel genera preview por PR y producción desde `main`.
+
+## Estado de los specs
+
+| Spec | Issue | Estado |
+|------|-------|--------|
+| [001 — Funnel de producto con PostHog](001-analytics-funnel.md) | [#54](https://github.com/and27/mundo/issues/54) | En curso |
+| 002 — Bucket privado + URLs firmadas | [#55](https://github.com/and27/mundo/issues/55) | Pendiente |
+| 003 — Páginas públicas de guías (SEO/AEO) | [#56](https://github.com/and27/mundo/issues/56) | Pendiente |
+| 004 — Landing enfocada + fake door de precio | [#57](https://github.com/and27/mundo/issues/57) | Pendiente |
+| 005 — Página demo para especialistas | [#58](https://github.com/and27/mundo/issues/58) | Pendiente |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       p-limit:
         specifier: ^4.0.0
         version: 4.0.0
+      posthog-js:
+        specifier: ^1.386.6
+        version: 1.386.6
       react:
         specifier: ^19.2.3
         version: 19.2.4
@@ -864,6 +867,12 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@posthog/core@1.32.3':
+    resolution: {integrity: sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==}
+
+  '@posthog/types@1.386.3':
+    resolution: {integrity: sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==}
+
   '@prisma/instrumentation@7.2.0':
     resolution: {integrity: sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==}
     peerDependencies:
@@ -1540,6 +1549,9 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2010,6 +2022,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
@@ -2089,6 +2104,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.4.9:
+    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -2337,6 +2355,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3261,6 +3282,12 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.386.6:
+    resolution: {integrity: sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3285,6 +3312,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3773,6 +3803,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4594,6 +4627,12 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@posthog/core@1.32.3':
+    dependencies:
+      '@posthog/types': 1.386.3
+
+  '@posthog/types@1.386.3': {}
+
   '@prisma/instrumentation@7.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -5261,6 +5300,9 @@ snapshots:
     dependencies:
       '@types/node': 20.19.32
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -5762,6 +5804,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  core-js@3.49.0: {}
+
   cross-env@10.1.0:
     dependencies:
       '@epic-web/invariant': 1.0.0
@@ -5836,6 +5880,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.9:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@16.6.1: {}
 
@@ -6239,6 +6287,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.4.8: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -7377,6 +7427,19 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.386.6:
+    dependencies:
+      '@posthog/core': 1.32.3
+      '@posthog/types': 1.386.3
+      core-js: 3.49.0
+      dompurify: 3.4.9
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
+  preact@10.29.2: {}
+
   prelude-ls@1.2.1: {}
 
   progress@2.0.3: {}
@@ -7407,6 +7470,8 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -8078,6 +8143,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Qué

Instrumenta el funnel core de mundo con PostHog (spec: `docs/specs/001-analytics-funnel.md`):

```
registro → guía generada → guía guardada → cuento escuchado → retorno
```

- Wrapper tipado en `src/lib/analytics.ts` — no-op si `NEXT_PUBLIC_POSTHOG_KEY` no existe; los componentes nunca importan posthog directamente.
- Init junto a Sentry en `instrumentation-client.ts` (pageviews SPA incluidos).
- `identify`/`reset` en login/registro/logout.
- `guia_generada` captura provider, fallback y emotionSource desde `_metadata` de la API — con esto medimos el fallback rate real.
- También establece el flujo spec-driven: `docs/specs/README.md`.

## Privacidad

Ningún evento envía texto libre del usuario (consultas de padres / contenido de guías). Solo metadatos de comportamiento.

## Para activarlo

1. Crear proyecto en posthog.com
2. `NEXT_PUBLIC_POSTHOG_KEY` en `.env` local y en Vercel
3. Ejercitar el flujo y verificar los 6 eventos en PostHog

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)